### PR TITLE
✨ [FEAT] 전화번호 간편 주문

### DIFF
--- a/src/main/java/likelion/kitalk/global/config/RedisConfig.java
+++ b/src/main/java/likelion/kitalk/global/config/RedisConfig.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
@@ -14,6 +15,7 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @Slf4j
 public class RedisConfig {
   @Bean
+  @Primary
   public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
     RedisTemplate<String, String> template = new RedisTemplate<>();
     template.setConnectionFactory(connectionFactory);

--- a/src/main/java/likelion/kitalk/global/config/RedisConfig.java
+++ b/src/main/java/likelion/kitalk/global/config/RedisConfig.java
@@ -14,6 +14,14 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @Configuration
 @Slf4j
 public class RedisConfig {
+  /**
+   * Primary RedisTemplate bean configured for simple String key/value operations.
+   *
+   * <p>Provides a RedisTemplate<String, String> with String serializers for keys and values;
+   * designated as the primary RedisTemplate for autowiring when multiple RedisTemplate beans exist.
+   *
+   * @return a RedisTemplate<String, String> configured for String serialization
+   */
   @Bean
   @Primary
   public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {

--- a/src/main/java/likelion/kitalk/phone/controller/PhoneOrderController.java
+++ b/src/main/java/likelion/kitalk/phone/controller/PhoneOrderController.java
@@ -1,0 +1,37 @@
+package likelion.kitalk.phone.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import likelion.kitalk.global.dto.BaseResponse;
+import likelion.kitalk.phone.dto.response.PhoneOrdersResponse;
+import likelion.kitalk.phone.dto.response.TopMenusResponse;
+import likelion.kitalk.phone.service.PhoneOrderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/phone")
+@RequiredArgsConstructor
+public class PhoneOrderController {
+
+  private final PhoneOrderService service;
+
+  @GetMapping("/orders")
+  @Operation(
+      summary = "최근 주문 5건 조회",
+      description = "전화번호로 필터링하여 최근 주문을 최대 5건까지 반환"
+  )
+  public BaseResponse<PhoneOrdersResponse> getRecentOrders(
+      @RequestParam("phone") String phone
+  ) {
+    return BaseResponse.success(service.getRecentOrders(phone));
+  }
+
+  @GetMapping("/top-menus")
+  @Operation(
+      summary = "가장 많이 주문한 메뉴 TOP 3",
+      description = "상위 3개 메뉴를 반환"
+  )
+  public BaseResponse<TopMenusResponse> getTopMenus(@RequestParam("phone") String phone) {
+    return BaseResponse.success(service.getTopMenusByPhone(phone));
+  }
+}

--- a/src/main/java/likelion/kitalk/phone/controller/PhoneOrderController.java
+++ b/src/main/java/likelion/kitalk/phone/controller/PhoneOrderController.java
@@ -15,6 +15,12 @@ public class PhoneOrderController {
 
   private final PhoneOrderService service;
 
+  /**
+   * Retrieve up to five most recent orders for the given phone number.
+   *
+   * @param phone the phone number to filter orders by
+   * @return a BaseResponse wrapping a PhoneOrdersResponse containing up to 5 most recent orders for the provided phone
+   */
   @GetMapping("/orders")
   @Operation(
       summary = "최근 주문 5건 조회",
@@ -26,6 +32,15 @@ public class PhoneOrderController {
     return BaseResponse.success(service.getRecentOrders(phone));
   }
 
+  /**
+   * Returns the top 3 most-ordered menu items for the specified phone number.
+   *
+   * Filters orders by the provided phone number and returns up to three menu entries
+   * ranked by order frequency.
+   *
+   * @param phone the phone number used to filter orders
+   * @return a BaseResponse wrapping a TopMenusResponse containing up to three top-ordered menu entries
+   */
   @GetMapping("/top-menus")
   @Operation(
       summary = "가장 많이 주문한 메뉴 TOP 3",

--- a/src/main/java/likelion/kitalk/phone/dto/request/PhoneSaveRequest.java
+++ b/src/main/java/likelion/kitalk/phone/dto/request/PhoneSaveRequest.java
@@ -1,0 +1,19 @@
+package likelion.kitalk.phone.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PhoneSaveRequest {
+
+  @Schema(description = "저장할 휴대폰 번호", example = "010-1234-5678")
+  private String phone;
+}

--- a/src/main/java/likelion/kitalk/phone/dto/response/PhoneOrdersResponse.java
+++ b/src/main/java/likelion/kitalk/phone/dto/response/PhoneOrdersResponse.java
@@ -1,0 +1,20 @@
+package likelion.kitalk.phone.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public record PhoneOrdersResponse(
+    @JsonProperty("results") List<OrderBlock> results
+) {
+  public record OrderBlock(
+      @JsonProperty("order_id") Long orderId,
+      @JsonProperty("orders") List<OrderLine> orders
+  ) {}
+
+  public record OrderLine(
+      @JsonProperty("menu_id") Long menuId,
+      @JsonProperty("menu_item") String menuItem,
+      @JsonProperty("price") Integer price,
+      @JsonProperty("temp") String temp
+  ) {}
+}

--- a/src/main/java/likelion/kitalk/phone/dto/response/TopMenusResponse.java
+++ b/src/main/java/likelion/kitalk/phone/dto/response/TopMenusResponse.java
@@ -1,0 +1,14 @@
+package likelion.kitalk.phone.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public record TopMenusResponse(
+    @JsonProperty("top_menus") List<MenuStat> topMenus
+) {
+  public record MenuStat(
+      @JsonProperty("menu_id") Long menuId,
+      @JsonProperty("menu_item") String menuItem,
+      @JsonProperty("count") Long count   // 주문 건수 기준(동일 주문 내 중복 1회)
+  ) {}
+}

--- a/src/main/java/likelion/kitalk/phone/exception/PhoneOrderErrorCode.java
+++ b/src/main/java/likelion/kitalk/phone/exception/PhoneOrderErrorCode.java
@@ -1,0 +1,16 @@
+package likelion.kitalk.phone.exception;
+
+import likelion.kitalk.global.exception.model.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum PhoneOrderErrorCode implements BaseErrorCode {
+  PHONE_ORDER_NOT_FOUND("PO001", "등록된 번호가 없습니다.", HttpStatus.NOT_FOUND);
+
+  private final String code;
+  private final String message;
+  private final HttpStatus status;
+}

--- a/src/main/java/likelion/kitalk/phone/service/PhoneOrderService.java
+++ b/src/main/java/likelion/kitalk/phone/service/PhoneOrderService.java
@@ -1,0 +1,82 @@
+package likelion.kitalk.phone.service;
+
+import likelion.kitalk.global.exception.CustomException;
+import likelion.kitalk.phone.dto.response.PhoneOrdersResponse;
+import likelion.kitalk.phone.dto.response.TopMenusResponse;
+import likelion.kitalk.phone.exception.PhoneOrderErrorCode;
+import likelion.kitalk.touch.entity.Order;
+import likelion.kitalk.touch.entity.OrderItems;
+import likelion.kitalk.touch.repository.OrderItemsRepository;
+import likelion.kitalk.touch.repository.OrderItemsRepository.TopMenuRow;
+import likelion.kitalk.touch.repository.OrderRepository;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+public class PhoneOrderService {
+
+  private final OrderRepository orderRepository;
+  private final OrderItemsRepository orderItemsRepository;
+
+  public PhoneOrderService(OrderRepository orderRepository, OrderItemsRepository orderItemsRepository) {
+    this.orderRepository = orderRepository;
+    this.orderItemsRepository = orderItemsRepository;
+  }
+
+  public PhoneOrdersResponse getRecentOrders(String phone) {
+    var pageable = PageRequest.of(0, 5);
+
+    var page = orderRepository.findByPhoneNumberOrderByCreatedAtDescIdDesc(phone, pageable);
+    var orders = page.getContent();
+
+    if (orders.isEmpty()) {
+      throw new CustomException(PhoneOrderErrorCode.PHONE_ORDER_NOT_FOUND);
+    }
+
+    List<Long> orderIds = orders.stream().map(Order::getId).toList();
+
+    List<OrderItems> allItems = orderItemsRepository
+        .findAllByOrderIdInOrderByOrderIdAscIdAsc(orderIds);
+
+    Map<Long, List<OrderItems>> grouped = allItems.stream()
+        .collect(Collectors.groupingBy(
+            OrderItems::getOrderId, LinkedHashMap::new, Collectors.toList()));
+
+    var blocks = new ArrayList<PhoneOrdersResponse.OrderBlock>();
+    for (Order o : orders) {
+      var lines = grouped.getOrDefault(o.getId(), List.of()).stream()
+          .map(oi -> new PhoneOrdersResponse.OrderLine(
+              oi.getMenuId(),
+              oi.getMenuName(),
+              oi.getPrice(),
+              oi.getTemp()
+          ))
+          .toList();
+
+      blocks.add(new PhoneOrdersResponse.OrderBlock(o.getId(), lines));
+    }
+
+    return new PhoneOrdersResponse(blocks);
+  }
+
+  public TopMenusResponse getTopMenusByPhone(String phone) {
+    List<TopMenuRow> rows = orderItemsRepository.findTopMenusByPhone(phone);
+
+    if (rows.isEmpty()) {
+      throw new CustomException(PhoneOrderErrorCode.PHONE_ORDER_NOT_FOUND);
+    }
+
+    var list = rows.stream()
+        .map(r -> new TopMenusResponse.MenuStat(
+            r.getMenuId(),
+            r.getMenuName(),
+            r.getOrderCount()
+        ))
+        .toList();
+
+    return new TopMenusResponse(list);
+  }
+}

--- a/src/main/java/likelion/kitalk/phone/service/PhoneOrderService.java
+++ b/src/main/java/likelion/kitalk/phone/service/PhoneOrderService.java
@@ -21,11 +21,25 @@ public class PhoneOrderService {
   private final OrderRepository orderRepository;
   private final OrderItemsRepository orderItemsRepository;
 
+  /**
+   * Creates a PhoneOrderService with the required repositories.
+   */
   public PhoneOrderService(OrderRepository orderRepository, OrderItemsRepository orderItemsRepository) {
     this.orderRepository = orderRepository;
     this.orderItemsRepository = orderItemsRepository;
   }
 
+  /**
+   * Retrieves up to five most recent orders for the given phone number and returns them with their items.
+   *
+   * The response contains an ordered list of order blocks (most recent first), each with the order ID
+   * and its associated order lines (menuId, menuName, price, temp). Order items are loaded for all
+   * returned orders and grouped by order ID to preserve the original order grouping.
+   *
+   * @param phone the phone number to look up orders for
+   * @return a PhoneOrdersResponse containing up to five recent orders and their items
+   * @throws CustomException if no orders are found for the provided phone (PhoneOrderErrorCode.PHONE_ORDER_NOT_FOUND)
+   */
   public PhoneOrdersResponse getRecentOrders(String phone) {
     var pageable = PageRequest.of(0, 5);
 
@@ -62,6 +76,16 @@ public class PhoneOrderService {
     return new PhoneOrdersResponse(blocks);
   }
 
+  /**
+   * Retrieves top-ordered menus for the customer identified by the given phone number.
+   *
+   * Queries order items to compute top menu statistics for that phone and returns them
+   * as a TopMenusResponse containing MenuStat entries (menuId, menuName, orderCount).
+   *
+   * @param phone the customer's phone number to query top menus for
+   * @return a TopMenusResponse containing the list of menu statistics
+   * @throws CustomException if no orders are found for the provided phone (PhoneOrderErrorCode.PHONE_ORDER_NOT_FOUND)
+   */
   public TopMenusResponse getTopMenusByPhone(String phone) {
     List<TopMenuRow> rows = orderItemsRepository.findTopMenusByPhone(phone);
 

--- a/src/main/java/likelion/kitalk/touch/controller/CartController.java
+++ b/src/main/java/likelion/kitalk/touch/controller/CartController.java
@@ -25,6 +25,19 @@ public class CartController {
 
   private final CartService cartService;
 
+  /**
+   * Add a menu item to the cart for the given session.
+   *
+   * <p>Accepts a session identifier and a CartAddRequest (typically containing menuId and quantity).
+   * On success returns HTTP 200 with a response map produced by the cart service (current cart state or
+   * operation result). On failure returns a ResponseEntity containing an error map and an appropriate
+   * HTTP status (CustomException yields its mapped status; other errors yield 500).</p>
+   *
+   * @param sessionId the touch session identifier for the cart
+   * @param request   the add-to-cart request (menu id and quantity)
+   * @return a ResponseEntity whose body is a map with either the service response (on success) or an
+   *         error payload (on failure)
+   */
   @Operation(
       summary = "메뉴 추가"
   )
@@ -52,6 +65,20 @@ public class CartController {
     }
   }
 
+  /**
+   * Partially updates a user's cart for the given session.
+   *
+   * <p>Applies the changes described in the provided CartUpdateRequest to the cart identified
+   * by sessionId and returns a response map with the updated cart state and metadata.
+   * On success returns HTTP 200 with the service response; on error the controller maps
+   * known domain errors to their corresponding HTTP status and returns a standardized
+   * error body, while unexpected errors yield HTTP 500.</p>
+   *
+   * @param sessionId the session identifier for the cart to update
+   * @param request   the partial update payload describing changes to apply to the cart
+   * @return a ResponseEntity containing a map with the operation result (on success) or
+   *         an error body (on failure)
+   */
   @Operation(
       summary = "장바구니 업데이트 (부분 업데이트)"
   )
@@ -79,6 +106,17 @@ public class CartController {
     }
   }
 
+  /**
+   * Remove a menu item from the cart for the given session.
+   *
+   * <p>Calls the cart service to remove the specified menu item and returns a ResponseEntity
+   * containing a result map. On success the body contains the service response; on failure
+   * the body is an error map with keys like `success`, `message`, `status`, and `timestamp`.</p>
+   *
+   * @param sessionId the session identifier for the cart
+   * @param request   request payload containing the menu item to remove (e.g., `menuId`)
+   * @return a ResponseEntity whose body is a map with the operation result or an error payload
+   */
   @Operation(
       summary = "특정 메뉴 삭제"
   )
@@ -106,6 +144,12 @@ public class CartController {
     }
   }
 
+  /**
+   * Removes all items from the cart for the specified session and returns the result.
+   *
+   * @param sessionId the session identifier of the cart to clear
+   * @return HTTP 200 with the service response map on success; on error returns a ResponseEntity containing an error body and the appropriate HTTP status
+   */
   @Operation(
       summary = "장바구니 전체 지우기"
   )
@@ -154,6 +198,18 @@ public class CartController {
     }
   }
 
+  /**
+   * Set the packaging type for the cart identified by the given session.
+   *
+   * <p>Accepts a PackagingRequest and updates the cart's packaging preference via the CartService.
+   * On success returns HTTP 200 with the service response map. If a CustomException occurs the
+   * response uses the exception's error status and message; unexpected errors return HTTP 500 with
+   * a generic error message.
+   *
+   * @param sessionId the cart session identifier
+   * @param request   request payload containing the desired packaging type
+   * @return ResponseEntity containing a map with the operation result or an error payload
+   */
   @Operation(
       summary = "포장 방식 설정"
   )

--- a/src/main/java/likelion/kitalk/touch/controller/CartController.java
+++ b/src/main/java/likelion/kitalk/touch/controller/CartController.java
@@ -30,7 +30,7 @@ public class CartController {
   )
 
   @PostMapping("/{sessionId}/add")
-  public ResponseEntity<Map<String, Object>> addToCart(@PathVariable String sessionId, @RequestBody CartAddRequest request) {
+  public ResponseEntity<Map<String, Object>> addToCart(@PathVariable("sessionId") String sessionId, @RequestBody CartAddRequest request) {
     log.info("장바구니 추가 API 호출 - sessionId: {}, menuId: {}, quantity: {}",
         sessionId, request.getMenuId(), request.getQuantity());
 
@@ -57,7 +57,7 @@ public class CartController {
   )
 
   @PutMapping("/{sessionId}/update")
-  public ResponseEntity<Map<String, Object>> updateCart(@PathVariable String sessionId, @RequestBody CartUpdateRequest request) {
+  public ResponseEntity<Map<String, Object>> updateCart(@PathVariable("sessionId") String sessionId, @RequestBody CartUpdateRequest request) {
     log.info("장바구니 업데이트 API 호출 - sessionId: {}, 요청 항목 수: {}",
         sessionId, request.getOrders() != null ? request.getOrders().size() : 0);
 
@@ -84,7 +84,7 @@ public class CartController {
   )
 
   @DeleteMapping("/{sessionId}/remove")
-  public ResponseEntity<Map<String, Object>> removeMenuItem(@PathVariable String sessionId, @RequestBody CartRemoveRequest request) {
+  public ResponseEntity<Map<String, Object>> removeMenuItem(@PathVariable("sessionId") String sessionId, @RequestBody CartRemoveRequest request) {
     log.info("메뉴 삭제 API 호출 - sessionId: {}, menuId: {}",
         sessionId, request.getMenuId());
 
@@ -111,7 +111,7 @@ public class CartController {
   )
 
   @DeleteMapping("/{sessionId}/clear")
-  public ResponseEntity<Map<String, Object>> clearCart(@PathVariable String sessionId) {
+  public ResponseEntity<Map<String, Object>> clearCart(@PathVariable("sessionId") String sessionId) {
     log.info("장바구니 비우기 API 호출 - sessionId: {}", sessionId);
 
     try {
@@ -159,7 +159,7 @@ public class CartController {
   )
 
   @PostMapping("/{sessionId}/packaging")
-  public ResponseEntity<Map<String, Object>> setPackagingType(@PathVariable String sessionId, @RequestBody PackagingRequest request) {  // ✅ 수정: @PathVariable 추가
+  public ResponseEntity<Map<String, Object>> setPackagingType(@PathVariable("sessionId") String sessionId, @RequestBody PackagingRequest request) {
     log.info("포장 방식 설정 API 호출 - sessionId: {}, packagingType: {}",
         sessionId, request.getPackagingType());
 

--- a/src/main/java/likelion/kitalk/touch/controller/PhoneController.java
+++ b/src/main/java/likelion/kitalk/touch/controller/PhoneController.java
@@ -2,6 +2,7 @@ package likelion.kitalk.touch.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import likelion.kitalk.global.exception.CustomException;
+import likelion.kitalk.phone.dto.request.PhoneSaveRequest;
 import likelion.kitalk.touch.dto.request.PhoneChoiceRequest;
 import likelion.kitalk.touch.dto.request.PhoneInputRequest;
 import likelion.kitalk.touch.service.PhoneService;
@@ -79,6 +80,57 @@ public class PhoneController {
             log.error("전화번호 입력 API 예상치 못한 오류 - sessionId: {}", sessionId, e);
             return createErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, 
                 "전화번호 입력 처리 중 오류가 발생했습니다");
+        }
+    }
+
+    @PostMapping("/{sessionId}/complete")
+    @Operation(
+        summary = "주문 완료(전화번호 입력 X)",
+        description = "전화번호 입력을 마친 세션에서 주문을 즉시 완료"
+    )
+    public ResponseEntity<Map<String, Object>> completeOrder(
+        @PathVariable("sessionId") String sessionId
+    ) {
+        log.info("주문 완료 API 호출 - sessionId: {}", sessionId);
+
+        try {
+            Map<String, Object> response = phoneService.completeOrderWithoutPhone(sessionId);
+
+            log.info("주문 완료 API 성공 - sessionId: {}", sessionId);
+            return ResponseEntity.ok(response);
+
+        } catch (CustomException e) {
+            log.warn("주문 완료 API 실패 - sessionId: {}, error: {}", sessionId, e.getMessage());
+            return createErrorResponse(e.getErrorCode().getStatus(), e.getMessage());
+
+        } catch (Exception e) {
+            log.error("주문 완료 API 예상치 못한 오류 - sessionId: {}", sessionId, e);
+            return createErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "주문 완료 처리 중 오류가 발생했습니다");
+        }
+    }
+
+    @PostMapping("/{sessionId}/phone_number")
+    @Operation(
+        summary = "전화번호 저장",
+        description = "세션에 전화번호 저장"
+    )
+    public ResponseEntity<Map<String, Object>> savePhone(
+        @PathVariable("sessionId") String sessionId,
+        @RequestBody PhoneSaveRequest request
+    ) {
+        log.info("전화번호 저장 API 호출 - sessionId: {}", sessionId);
+        try {
+            Map<String, Object> response = phoneService.savePhone(sessionId, request.getPhone());
+            log.info("전화번호 저장 API 성공 - sessionId: {}", sessionId);
+            return ResponseEntity.ok(response);
+
+        } catch (CustomException e) {
+            log.warn("전화번호 저장 API 실패 - sessionId: {}, error: {}", sessionId, e.getMessage());
+            return createErrorResponse(e.getErrorCode().getStatus(), e.getMessage());
+
+        } catch (Exception e) {
+            log.error("전화번호 저장 API 예상치 못한 오류 - sessionId: {}", sessionId, e);
+            return createErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "전화번호 저장 중 오류가 발생했습니다");
         }
     }
 

--- a/src/main/java/likelion/kitalk/touch/controller/PhoneController.java
+++ b/src/main/java/likelion/kitalk/touch/controller/PhoneController.java
@@ -53,6 +53,15 @@ public class PhoneController {
         }
     }
 
+    /**
+     * Handle submission of a user's phone number for a given session.
+     *
+     * Processes the provided phone number via the phone service and returns the service's response map on success.
+     *
+     * @param sessionId identifier for the current session
+     * @param request   request DTO containing the phone number to process
+     * @return ResponseEntity containing a Map<String, Object> with the service result on success, or a structured error payload on failure
+     */
     @Operation(
         summary = "전화번호 입력"
     )
@@ -83,6 +92,14 @@ public class PhoneController {
         }
     }
 
+    /**
+     * Completes an order for the given session when no phone number is provided.
+     *
+     * Calls the service to finalize the order immediately for the specified session.
+     *
+     * @param sessionId the touch-session identifier for which the order should be completed
+     * @return a ResponseEntity containing the service result map on success (HTTP 200), or an error response map with an appropriate HTTP status when completion fails
+     */
     @PostMapping("/{sessionId}/complete")
     @Operation(
         summary = "주문 완료(전화번호 입력 X)",
@@ -109,6 +126,14 @@ public class PhoneController {
         }
     }
 
+    /**
+     * Persist the provided phone number for the given session.
+     *
+     * <p>Accepts a PhoneSaveRequest and stores its phone value in the session identified by {@code sessionId}.
+     *
+     * @param request PhoneSaveRequest whose {@code getPhone()} value will be saved for the session
+     * @return ResponseEntity containing the service response map on success (HTTP 200) or an error response map on failure
+     */
     @PostMapping("/{sessionId}/phone_number")
     @Operation(
         summary = "전화번호 저장",
@@ -134,7 +159,19 @@ public class PhoneController {
         }
     }
 
-    // 에러 응답 생성
+    /**
+     * Build a standardized error response payload wrapped in a ResponseEntity with the given HTTP status.
+     *
+     * The response body is a Map with keys:
+     * - "success" (Boolean): always false
+     * - "message" (String): provided human-readable error message
+     * - "status" (Integer): numeric HTTP status code
+     * - "timestamp" (Long): epoch milliseconds when the response was created
+     *
+     * @param status  HTTP status to set on the ResponseEntity and include in the payload
+     * @param message Human-readable error message to include in the payload
+     * @return ResponseEntity containing the error map and the provided HTTP status
+     */
     private ResponseEntity<Map<String, Object>> createErrorResponse(HttpStatus status, String message) {
         Map<String, Object> errorResponse = new HashMap<>();
         errorResponse.put("success", false);

--- a/src/main/java/likelion/kitalk/touch/repository/OrderItemsRepository.java
+++ b/src/main/java/likelion/kitalk/touch/repository/OrderItemsRepository.java
@@ -1,0 +1,41 @@
+package likelion.kitalk.touch.repository;
+
+import java.util.Collection;
+import java.util.List;
+import likelion.kitalk.touch.entity.OrderItems;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface OrderItemsRepository extends JpaRepository<OrderItems, Long> {
+
+  @Query("""
+        SELECT oi
+        FROM OrderItems oi
+        WHERE oi.orderId IN :orderIds
+        ORDER BY oi.orderId ASC, oi.id ASC
+    """)
+  List<OrderItems> findAllByOrderIdInOrderByOrderIdAscIdAsc(
+      @Param("orderIds") Collection<Long> orderIds
+  );
+
+  @Query(value = """
+        SELECT 
+            oi.menu_id   AS menuId,
+            oi.menu_name AS menuName,
+            COUNT(DISTINCT oi.order_id) AS orderCount
+        FROM order_items oi
+        JOIN orders o ON o.id = oi.order_id
+        WHERE o.phone_number = :phone
+        GROUP BY oi.menu_id, oi.menu_name
+        ORDER BY orderCount DESC, oi.menu_id ASC
+        LIMIT 3
+    """, nativeQuery = true)
+  List<TopMenuRow> findTopMenusByPhone(@Param("phone") String phone);
+
+  interface TopMenuRow {
+    Long getMenuId();
+    String getMenuName();
+    Long getOrderCount();
+  }
+}

--- a/src/main/java/likelion/kitalk/touch/repository/OrderItemsRepository.java
+++ b/src/main/java/likelion/kitalk/touch/repository/OrderItemsRepository.java
@@ -9,6 +9,12 @@ import org.springframework.data.repository.query.Param;
 
 public interface OrderItemsRepository extends JpaRepository<OrderItems, Long> {
 
+  /**
+   * Retrieves all OrderItems whose orderId is in the given collection, ordered by orderId then item id (both ascending).
+   *
+   * @param orderIds collection of order IDs to fetch items for
+   * @return list of matching OrderItems ordered by orderId ASC, id ASC
+   */
   @Query("""
         SELECT oi
         FROM OrderItems oi
@@ -19,6 +25,17 @@ public interface OrderItemsRepository extends JpaRepository<OrderItems, Long> {
       @Param("orderIds") Collection<Long> orderIds
   );
 
+  /**
+   * Returns the top 3 most-ordered menus for a customer phone number.
+   *
+   * Executes a native query that counts distinct orders per menu (menuId, menuName)
+   * for orders associated with the given phone number and returns the three menus
+   * with highest distinct-order counts; results are ordered by order count
+   * descending then menuId ascending and mapped to the TopMenuRow projection.
+   *
+   * @param phone the customer's phone number to filter orders by
+   * @return a list of up to three TopMenuRow projections containing menuId, menuName, and orderCount
+   */
   @Query(value = """
         SELECT 
             oi.menu_id   AS menuId,
@@ -34,8 +51,29 @@ public interface OrderItemsRepository extends JpaRepository<OrderItems, Long> {
   List<TopMenuRow> findTopMenusByPhone(@Param("phone") String phone);
 
   interface TopMenuRow {
-    Long getMenuId();
-    String getMenuName();
-    Long getOrderCount();
+    /**
+ * Returns the menu's identifier.
+ *
+ * Maps to the `menu_id` column produced by the repository query.
+ *
+ * @return the menu id, or null if not present
+ */
+Long getMenuId();
+    /**
+ * Returns the menu's display name.
+ *
+ * This value maps to the native query column `menuName` in the projection.
+ *
+ * @return the menu name (as returned by the query)
+ */
+String getMenuName();
+    /**
+ * Returns the number of distinct orders that included this menu item.
+ *
+ * <p>Maps to the `orderCount` column from the native query; may be null if no value is present.</p>
+ *
+ * @return the count of distinct orders for this menu
+ */
+Long getOrderCount();
   }
 }

--- a/src/main/java/likelion/kitalk/touch/repository/OrderRepository.java
+++ b/src/main/java/likelion/kitalk/touch/repository/OrderRepository.java
@@ -1,0 +1,9 @@
+package likelion.kitalk.touch.repository;
+
+import likelion.kitalk.touch.entity.Order;
+import org.springframework.data.domain.Page;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+  Page<Order> findByPhoneNumberOrderByCreatedAtDescIdDesc(String phoneNumber, org.springframework.data.domain.Pageable pageable);
+}

--- a/src/main/java/likelion/kitalk/touch/repository/OrderRepository.java
+++ b/src/main/java/likelion/kitalk/touch/repository/OrderRepository.java
@@ -5,5 +5,15 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OrderRepository extends JpaRepository<Order, Long> {
-  Page<Order> findByPhoneNumberOrderByCreatedAtDescIdDesc(String phoneNumber, org.springframework.data.domain.Pageable pageable);
+  /**
+ * Finds orders for the given phone number, returning results in pages.
+ *
+ * Returns a Page of Order entities whose phoneNumber equals the provided value,
+ * ordered by createdAt descending and then id descending.
+ *
+ * @param phoneNumber the phone number to filter orders by (exact match)
+ * @param pageable    pagination information (page number and size); sorting here is ignored in favor of the method's defined ordering
+ * @return a page of matching Order entities ordered by createdAt desc, id desc
+ */
+Page<Order> findByPhoneNumberOrderByCreatedAtDescIdDesc(String phoneNumber, org.springframework.data.domain.Pageable pageable);
 }

--- a/src/main/resources/db/migration/V8__add_modified_at_to_orders.sql
+++ b/src/main/resources/db/migration/V8__add_modified_at_to_orders.sql
@@ -1,0 +1,2 @@
+ALTER TABLE orders
+    ADD COLUMN modified_at DATETIME NULL DEFAULT NULL;


### PR DESCRIPTION
<!-- PR 제목은 "[태그/#이슈번호] 작업 내용 요약" 으로 작성해주세요 -->
<!-- ex) ✨ [FEAT/#1] 로그인 페이지 UI 구현 -->

## 🚀 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 closed #Issue_number를 적어주세요 -->
- closed #8 


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 과거 주문 내역 반환
- 자주 주문한 메뉴 반환
- 전화번호 없이 주문 완료
- 전화번호 저장(세션 Id)


## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?

      
## 📸 스크린샷 (선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->


## 💬 리뷰 요구사항(선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!--ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->


## ➕ 추후 계획(선택)
<!-- 추가로 계획 중인 기능이나 리팩토링 예정 중인 기능이 있다면 작성해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added phone-based endpoints to view recent orders (up to 5) and top 3 frequently ordered menus.
  - Enabled saving a phone number and completing orders (with or without a phone) in the touch flow.

- Bug Fixes
  - Improved reliability of cart endpoints by explicitly binding session IDs.

- Chores
  - Designated primary Redis template for configuration.
  - Added DB migration to support order modification timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->